### PR TITLE
Fixing max width of logo on order in admin

### DIFF
--- a/upload/admin/view/template/extension/payment/bambora_online_checkout_order.tpl
+++ b/upload/admin/view/template/extension/payment/bambora_online_checkout_order.tpl
@@ -58,6 +58,7 @@ getTransactionInformation();
     margin: 3px 3px 3px 0;
 }
 .bambora-logo {
-    max-width:300px;
+    width:300px;
+    max-width:100%;
 }
 </style>

--- a/upload/admin/view/template/extension/payment/bambora_online_checkout_order.twig
+++ b/upload/admin/view/template/extension/payment/bambora_online_checkout_order.twig
@@ -58,6 +58,7 @@ getTransactionInformation();
     margin: 3px 3px 3px 0;
 }
 .bambora-logo {
-    max-width:300px;
+    width:300px;
+    max-width:100%;
 }
 </style>


### PR DESCRIPTION
Setting the max with of logo display on orders in admin to 100 percent, so it doesn't go outside the div/window.

The 300px with is probably never needed, but I kept it just to be sure (bc). Could maybe be considered set to a lower value.

![before](https://user-images.githubusercontent.com/858132/63087239-4eb5a600-bf5a-11e9-99bd-fead9607912e.png)

![after](https://user-images.githubusercontent.com/858132/63087245-51b09680-bf5a-11e9-8395-b26f9a5433ec.png)
